### PR TITLE
Add invoice_id to search params

### DIFF
--- a/app/controllers/api/v1/search_transactions_controller.rb
+++ b/app/controllers/api/v1/search_transactions_controller.rb
@@ -12,7 +12,7 @@ class Api::V1::SearchTransactionsController < ApplicationController
   private
 
   def transaction_params
-    params.permit(:id, :credit_card_number, :result, :created_at, :updated_at)
+    params.permit(:id, :credit_card_number, :invoice_id, :result, :created_at, :updated_at)
   end
 
 end

--- a/spec/factories/merchants.rb
+++ b/spec/factories/merchants.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :merchant do
     sequence :name do |n|
-      "SellingStuff#{n}"
+      "Selling Stuff#{n}"
     end
   end
 end


### PR DESCRIPTION
This adds `invoice_id` to the `transactions` strong params. All tests passing.

@drod1000 